### PR TITLE
Wrap input in globby to support recursive glob

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ if (argv.use.indexOf("postcss-import") !== -1) {
 var inputFiles = globby.sync(argv._);
 if (!inputFiles.length) {
   if (argv.input) {
-    inputFiles = Array.isArray(argv.input) ? argv.input : [argv.input];
+    inputFiles = Array.isArray(argv.input) ? argv.input : globby.sync(argv.input);
   } else { // use stdin if nothing else is specified
     inputFiles = [undefined];
   }


### PR DESCRIPTION
Adds the ability to recursive process css files, given the following structure:

- dist
  - css
    - components
      - component.css
    - base.css

Running `postcss-cli dist/**/*.css` would only process base.css, with the supplied fix, running `postcss-cli --input=dist/**/*.css` would both process component.css and base.css