### PR TITLE
fix `--map` option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: clean lint test
 lint:
 	./node_modules/.bin/jshint *.js
 
-TESTS = opts source-maps source-maps-file stdout stdin config config-all config-wildcard js-config js-config-all invalid warning no-plugin
+TESTS = opts source-maps source-maps-file import-with-plugin stdout stdin config config-all config-wildcard js-config js-config-all invalid warning no-plugin
 
 
 DIFF = diff -q
@@ -68,6 +68,10 @@ test/build/source-maps-file.css: test/in.css
 	./bin/postcss -u postcss-url --postcss-url.url=rebase --map file -o $@ $<
 	$(DIFF) $@ $(subst build,ref,$@)
 	$(DIFF) ${@}.map $(subst build,ref,${@}.map)
+
+test/build/import-with-plugin.css: test/import-with-plugin.css
+	./bin/postcss -u postcss-import --map -o $@ $<
+	$(DIFF) $@ $(subst build,ref,$@)
 
 test/build/stdout.css: test/in.css
 	./bin/postcss --use ./test/dummy-plugin $< > $@

--- a/index.js
+++ b/index.js
@@ -129,9 +129,12 @@ var customSyntaxOptions = ['syntax', 'parser', 'stringifier']
 
 
 var mapOptions = argv.map;
-// treat `--map file` as `--no-map.inline`
 if (mapOptions === 'file') {
+  // treat `--map file` as `--no-map.inline`
   mapOptions = { inline: false };
+} else if (mapOptions === true) {
+  // treat `--map` as `--map.inline`
+  mapOptions = { inline: true };
 }
 
 var async = require('neo-async');

--- a/test/import-with-plugin-source-maps.css
+++ b/test/import-with-plugin-source-maps.css
@@ -1,0 +1,6 @@
+body {
+  background: url(image.png);
+  display: flex;
+}
+
+/*# sourceMappingURL=import-with-plugin-source-maps.css.map */

--- a/test/import-with-plugin-source-maps.css.map
+++ b/test/import-with-plugin-source-maps.css.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["../import-with-plugin-source-maps.css"],"names":[],"mappings":"AAAA;EACE,2BAA2B;EAC3B,cAAc;CACf","file":"import-with-plugin-source-maps.css","sourcesContent":["body {\n  background: url(image.png);\n  display: flex;\n}\n"]}

--- a/test/import-with-plugin.css
+++ b/test/import-with-plugin.css
@@ -1,0 +1,5 @@
+@import "import-with-plugin-source-maps.css";
+
+.bar {
+  color: #0F0;
+}

--- a/test/ref/import-with-plugin.css
+++ b/test/ref/import-with-plugin.css
@@ -1,0 +1,10 @@
+body {
+  background: url(image.png);
+  display: flex;
+}
+
+.bar {
+  color: #0F0;
+}
+
+/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi4uLy4uL2ltcG9ydC13aXRoLXBsdWdpbi1zb3VyY2UtbWFwcy5jc3MiLCIuLi9pbXBvcnQtd2l0aC1wbHVnaW4uY3NzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBO0VBQ0UsMkJBQTJCO0VBQzNCLGNBQWM7Q0FDZjs7QUNERDtFQUNFLFlBQVk7Q0FDYiIsImZpbGUiOiJpbXBvcnQtd2l0aC1wbHVnaW4uY3NzIiwic291cmNlc0NvbnRlbnQiOlsiYm9keSB7XG4gIGJhY2tncm91bmQ6IHVybChpbWFnZS5wbmcpO1xuICBkaXNwbGF5OiBmbGV4O1xufVxuIiwiQGltcG9ydCBcImltcG9ydC13aXRoLXBsdWdpbi1zb3VyY2UtbWFwcy5jc3NcIjtcblxuLmJhciB7XG4gIGNvbG9yOiAjMEYwO1xufVxuIl19 */


### PR DESCRIPTION
By default inline maps are generated with postcss-cli.  
However `.map` file is generated when `.css` file, which import other `.css` files containing `.map` files is transformed with `postcss-import` plugin.

I wrote sample code to check the bug.
Please read it.

**Sample code**: 
[postcsss-map-option-bug-test.zip](https://github.com/postcss/postcss-cli/files/180831/postcsss-map-option-bug-test.zip)
