### PR TITLE
fix ES6 plugin initialization

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ var plugins = argv.use.map(function(name) {
     plugin = require(name);
   }
   if (name in argv) {
-    plugin = plugin(argv[name]);
+    plugin = typeof plugin === 'function' ? plugin(argv[name]) : plugin.default(argv[name]);
   } else {
     plugin = plugin.postcss || plugin();
   }


### PR DESCRIPTION
Plugins written in ES6 or compiled with Babel6 export a default function. Issue discovered when using https://github.com/2createStudio/postcss-sprites with postcss-cli. I got error on line 107 of postcss-cli/index.js: `plugin = plugin(argv[name]);` `TypeError: plugin is not a function`. I found that postcss-sprites is using Babel6 which no longer uses CommonJS module.exports to export the default function.

Since this may become an issue with other plugins, I believe the fix should be made in postcss-cli.

I used the following resources:
http://stackoverflow.com/questions/33505992/babel-6-changes-how-it-exports-default
https://medium.com/@kentcdodds/misunderstanding-es6-modules-upgrading-babel-tears-and-a-solution-ad2d5ab93ce0#.swyxpwu8b
