### PR TITLE
Fix booleans in config file

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "postcss": "^5.0.0",
     "read-file-stdin": "^0.2.0",
     "resolve": "^1.1.6",
-    "yargs": "^3.8.0"
+    "yargs": "^3.32.0"
   },
   "optionalDependencies": {
     "chokidar": "^1.0.3"


### PR DESCRIPTION
Due to https://github.com/yargs/yargs/pull/223, using booleans (like `replace: true`) in the config file doesn't work if `npm install` picks up a version of yargs lower than 3.18.1, so bump yargs to 3.32.0.
