### PR TITLE
Poll for changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,10 @@ var argv = require("yargs")
   .describe('s', 'Alternative input syntax parser')
   .alias('p', 'parser')
   .describe('p', 'Alternative CSS parser')
+  .option('poll', {
+    describe: 'Use polling to monitor for changes.',
+    default: false,
+  })
   .alias('t', 'stringifier')
   .describe('t', 'Alternative output stringifier')
   .alias('w', 'watch')
@@ -144,8 +148,16 @@ async.forEach(inputFiles, compile, onError);
 function fsWatcher(entryPoints) {
   var watchedFiles = entryPoints;
   var index = {}; // source files by entry point
+  var opts = {};
 
-  var watcher = require('chokidar').watch(watchedFiles);
+  if (argv.poll || typeof argv.poll === 'number') {
+    opts.usePolling = true;
+    opts.interval = argv.poll !== true
+      ? argv.poll
+      : undefined;
+  }
+
+  var watcher = require('chokidar').watch(watchedFiles, opts);
   // recompile if any watched file is modified
   // TODO: only recompile relevant entry point
   watcher.on('change', function() {


### PR DESCRIPTION
Use polling to monitor for changes. Omitting the interval will default
to 100ms. This option is useful if you're watching an NFS volume. Fixes #13