### PR TITLE
Multiple files with stdout

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,9 +89,6 @@ if (!inputFiles.length) {
   // use stdin if nothing else is specified
   inputFiles = [undefined];
 }
-if (inputFiles.length > 1 && !argv.dir && !argv.replace) {
-  throw 'Please specify either --replace or --dir [output directory] for your files';
-}
 
 // load and configure plugin array
 var plugins = argv.use.map(function(name) {


### PR DESCRIPTION
I removed the error thrown when you have multiple files without a set output. This would allow you to for example lint multiple files without having a folder to put the linted files in.

I didn’t make a test in the `Makefile` because I don’t have any experience with it and after trying for a long time I gave up :)

Will this cause any other issues that I’m not aware of?