### PR TITLE
Fix Watcher with postcss-imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -166,9 +166,14 @@ function fsWatcher(entryPoints) {
       return files.concat(index[entryPoint]);
     }, []);
     // update watch list
-    watcher.unwatch(watchedFiles);
+    var newSources = [];
+    sources.forEach(function (src) {
+      if (watchedFiles.indexOf(src) === -1) {
+        newSources.push(src);
+      }
+    });
     watcher.add(sources);
-    watchedFiles = sources;
+    watchedFiles = watchedFiles.concat(newSources);
   };
 }
 


### PR DESCRIPTION
For setups with multiple entry points (ie: two or more), the `updateWatchedFiles` func would 'unwatch' files imported by the first entrypoint when resolving imports of the next.

To fix this I have modified the `updateWatchedFiles` func to never explicitally unwatch any sources but instead only add new sources which were not already being watched.
