### PR TITLE
Update the version of dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ var argv = require("yargs")
       'postcss version',
       require('./node_modules/postcss/package.json').version
     ].join(' ');
-  }, 'v')
+  })
   .alias('v', 'version')
   .help('h')
   .alias('h', 'help')

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "postcss": "^5.0.0",
     "read-file-stdin": "^0.2.0",
     "resolve": "^1.1.6",
-    "yargs": "^3.32.0"
+    "yargs": "^4.7.1"
   },
   "optionalDependencies": {
     "chokidar": "^1.0.3"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "jshint": "^2.9.2",
-    "postcss-import": "^7.1.0",
+    "postcss-import": "^8.1.2",
     "postcss-url": "^5.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "yargs": "^4.7.1"
   },
   "optionalDependencies": {
-    "chokidar": "^1.0.3"
+    "chokidar": "^1.5.1"
   },
   "devDependencies": {
     "jshint": "^2.6.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "chokidar": "^1.5.1"
   },
   "devDependencies": {
-    "jshint": "^2.6.3",
+    "jshint": "^2.9.2",
     "postcss-import": "^7.1.0",
     "postcss-url": "^4.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
   "devDependencies": {
     "jshint": "^2.9.2",
     "postcss-import": "^7.1.0",
-    "postcss-url": "^4.0.0"
+    "postcss-url": "^5.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Damian Krzeminski <pirxpilot@code42day.com>",
   "license": "MIT",
   "dependencies": {
-    "globby": "^3.0.1",
+    "globby": "^4.1.0",
     "mkdirp": "^0.5.1",
     "neo-async": "^1.0.0",
     "postcss": "^5.0.0",


### PR DESCRIPTION
Some deps are the old version, and the updates included major updates. I tweaked to `index.js` to catch up the major update in yargs.
+ Update yargs to v4.7.1 from v3.32.0
+ Update chokidar to v1.5.1 from v1.0.3
+ Update jshint to v2.9.2 from v2.6.3
+ Update postcss-url to v5.1.2 from v4.0.0
+ Update globby to v4.1.0 from v3.0.1
+ Update postcss-import to v8.1.2 from v7.1.0