### PR TITLE
Adds nested directory output using option --inputContext

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ test: test/build \
 	test-version \
 	$(patsubst %,test/build/%.css,$(TESTS)) \
 	test-multi \
+	test-context \
 	test-replace \
 	test-local-plugins
 
@@ -25,6 +26,10 @@ test-version:
 test-multi:
 	./bin/postcss -u postcss-url --dir test/build test/multi*.css
 	$(DIFF) test/build/multi*.css --to-file=test/ref
+
+test-context:
+	./bin/postcss -c test/config-context.js
+	$(DIFF) test/build/test-context/in.css test/ref/test-context/in.css
 
 test-replace:
 	 cp test/replace.css test/build/replace.css

--- a/Readme.md
+++ b/Readme.md
@@ -33,6 +33,10 @@ Output files location. Either `--output`, `--dir` or `--replace` option, but
 not all of them, need to be specified. `--dir` or `--replace` needs to be used
 if multiple input file is provided.
 
+#### `--inputContext|-x`
+
+Optional declaration of parent folder for input when `--dir` is used and an input glob may return nested directories. When applied, `--input` glob will be relative to `--inputContext` and folder structure inside `--inputContext` will be mimicked in `--dir`
+
 #### `--replace|-r`
 
 Replace input file(s) with generated output. Either `--output`, `--dir` or

--- a/test/config-context.js
+++ b/test/config-context.js
@@ -1,0 +1,9 @@
+module.exports = {
+  use: "postcss-url",
+  input: "**/in.css",
+  inputContext: "test",
+  dir: "test/build",
+  "postcss-url": {
+    url: function(url) { return "http://example.com/" + url; }
+  }
+};

--- a/test/ref/test-context/in.css
+++ b/test/ref/test-context/in.css
@@ -1,0 +1,4 @@
+body {
+  background: url(http://example.com/image.png);
+  display: flex;
+}

--- a/test/test-context/in.css
+++ b/test/test-context/in.css
@@ -1,0 +1,4 @@
+body {
+  background: url(image.png);
+  display: flex;
+}


### PR DESCRIPTION
`--inputContext`: Optional declaration of parent folder for input when `--dir` is used and an input glob may return nested directories. When applied, `--input` glob will be relative to `--inputContext` and folder structure inside `--inputContext` will be mimicked in `--dir`
