### PR TITLE
support es6/babel export default

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,6 +103,9 @@ var plugins = argv.use.map(function(name) {
   } else {
     plugin = require(name);
   }
+  if (plugin.default && typeof plugin.default === 'function') {
+    plugin = plugin.default
+  }
   if (name in argv) {
     plugin = plugin(argv[name]);
   } else {


### PR DESCRIPTION
[postcss-sprites](https://github.com/2createStudio/postcss-sprites) use es6 and babeljs (and maybe there are other plugins do the same thing).

For modules compiled with babel, they may need to be required like this

```
var sprites = require('postcss-sprites').default;
```

So I just add one more check to in the cli.