### PR TITLE
Release v2.6.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,18 @@
+2.6.0 / 2016-08-30
+==================
+
+  * Add log option
+  * Update postcss-import to v8.1.2 from v7.1.0
+  * Update globby to v4.1.0 from v3.0.1
+  * Update postcss-url to v5.1.2 from v4.0.0
+  * Update jshint to v2.9.2 from v2.6.3
+  * Update chokidar to v1.5.1 from v1.0.3
+  * Update yargs to v4.7.1 from v3.32.0
+  * Support es6 export
+  * Allow running without plugins
+  * Add test for --poll
+  * Add --poll flag
+
 2.5.2 / 2016-04-18
 ==================
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: clean lint test
 lint:
 	./node_modules/.bin/jshint *.js
 
-TESTS = opts source-maps source-maps-file stdout stdin config config-all config-wildcard js-config js-config-all invalid warning
+TESTS = opts source-maps source-maps-file stdout stdin config config-all config-wildcard js-config js-config-all invalid warning no-plugin
 
 
 DIFF = diff -q
@@ -82,6 +82,9 @@ test/build/invalid.css: test/in-force-error.css
 
 test/build/warning.css: test/in-warning.css
 	./bin/postcss --use ./test/dummy-plugin -o $@ $< && echo Warning is OK here....
+
+test/build/no-plugin.css: test/no-plugin.css
+	./bin/postcss ./test/no-plugin.css -o $@ && echo It works without plugins
 
 test/build/config.css: test/in.css
 	./bin/postcss -u postcss-url -c test/config.json -o $@ $<

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,17 @@ test-watch: test/import-*.css
 	kill `cat test/watch.pid` # FIXME: never reached on failure
 	rm test/watch.pid
 
+test-watch-poll: test/import-*.css
+	echo '@import "import-foo.css";' > test/import-index.css
+	./bin/postcss -c test/config-watch.js -w --poll & echo $$! > test/watch.pid
+	sleep 1
+	$(DIFF) test/build/watch.css test/ref/watch-1.css
+	echo '@import "import-bar.css";' >> test/import-index.css
+	sleep 1
+	$(DIFF) test/build/watch.css test/ref/watch-2.css
+	kill `cat test/watch.pid` # FIXME: never reached on failure
+	rm test/watch.pid
+
 test-local-plugins:
 	cd test; ../bin/postcss --use a-dummy-plugin --local-plugins -o build/local-plugins in.css
 

--- a/index.js
+++ b/index.js
@@ -30,6 +30,10 @@ var argv = require("yargs")
   .describe('s', 'Alternative input syntax parser')
   .alias('p', 'parser')
   .describe('p', 'Alternative CSS parser')
+  .option('poll', {
+    describe: 'Use polling to monitor for changes.',
+    default: false,
+  })
   .alias('t', 'stringifier')
   .describe('t', 'Alternative output stringifier')
   .alias('w', 'watch')
@@ -146,8 +150,16 @@ async.forEach(inputFiles, compile, onError);
 function fsWatcher(entryPoints) {
   var watchedFiles = entryPoints;
   var index = {}; // source files by entry point
+  var opts = {};
 
-  var watcher = require('chokidar').watch(watchedFiles);
+  if (argv.poll) {
+    opts.usePolling = true;
+  }
+  if (typeof argv.poll === 'number') {
+    opts.interval = argv.poll;
+  }
+
+  var watcher = require('chokidar').watch(watchedFiles, opts);
   // recompile if any watched file is modified
   // TODO: only recompile relevant entry point
   watcher.on('change', function() {

--- a/index.js
+++ b/index.js
@@ -106,6 +106,9 @@ var plugins = argv.use.map(function(name) {
   } else {
     return null;
   }
+  if (plugin.default && typeof plugin.default === 'function') {
+    plugin = plugin.default;
+  }
   if (name in argv) {
     plugin = plugin(argv[name]);
   } else {

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ var argv = require("yargs")
       'postcss version',
       require('./node_modules/postcss/package.json').version
     ].join(' ');
-  }, 'v')
+  })
   .alias('v', 'version')
   .help('h')
   .alias('h', 'help')

--- a/index.js
+++ b/index.js
@@ -49,9 +49,6 @@ var argv = require("yargs")
   .help('h')
   .alias('h', 'help')
   .check(function(argv) {
-    if (!argv.use) {
-      throw 'Please specify at least one plugin name.';
-    }
     if (argv._.length && argv.input) {
       throw 'Both positional arguments and --input option used for `input file`: please only use one of them.';
     }
@@ -104,8 +101,10 @@ var plugins = argv.use.map(function(name) {
   if (local) {
     var resolved = resolve.sync(name, {basedir: process.cwd()});
     plugin = require(resolved);
-  } else {
+  } else if (name) {
     plugin = require(name);
+  } else {
+    return null;
   }
   if (name in argv) {
     plugin = plugin(argv[name]);
@@ -136,7 +135,7 @@ var path = require('path');
 var readFile = require('read-file-stdin');
 var path = require('path');
 var postcss = require('postcss');
-var processor = postcss(plugins);
+var processor = plugins[0] ? postcss(plugins) : postcss();
 var mkdirp = require('mkdirp');
 
 // hook for dynamically updating the list of watched files

--- a/index.js
+++ b/index.js
@@ -36,6 +36,8 @@ var argv = require("yargs")
   })
   .alias('t', 'stringifier')
   .describe('t', 'Alternative output stringifier')
+  .alias('l', 'log')
+  .describe('l', 'Log when file is written')
   .alias('w', 'watch')
   .describe('w', 'auto-recompile when detecting source changes')
   .requiresArg(['u', 'c', 'i', 'o', 'd', 's', 'p', 't'])
@@ -269,6 +271,10 @@ function writeFile(name, content, fn) {
       fn(err);
     } else {
       fs.writeFile(name, content, fn);
+
+      if (argv.log) {
+        console.log('Generated file: ' + name);
+      }
     }
   });
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "postcss": "^5.0.0",
     "read-file-stdin": "^0.2.0",
     "resolve": "^1.1.6",
-    "yargs": "^3.32.0"
+    "yargs": "^4.7.1"
   },
   "optionalDependencies": {
     "chokidar": "^1.0.3"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "jshint": "^2.9.2",
-    "postcss-import": "^7.1.0",
+    "postcss-import": "^8.1.2",
     "postcss-url": "^5.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "yargs": "^4.7.1"
   },
   "optionalDependencies": {
-    "chokidar": "^1.0.3"
+    "chokidar": "^1.5.1"
   },
   "devDependencies": {
     "jshint": "^2.6.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "chokidar": "^1.5.1"
   },
   "devDependencies": {
-    "jshint": "^2.6.3",
+    "jshint": "^2.9.2",
     "postcss-import": "^7.1.0",
     "postcss-url": "^4.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
   "devDependencies": {
     "jshint": "^2.9.2",
     "postcss-import": "^7.1.0",
-    "postcss-url": "^4.0.0"
+    "postcss-url": "^5.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Damian Krzeminski <pirxpilot@code42day.com>",
   "license": "MIT",
   "dependencies": {
-    "globby": "^3.0.1",
+    "globby": "^4.1.0",
     "mkdirp": "^0.5.1",
     "neo-async": "^1.0.0",
     "postcss": "^5.0.0",

--- a/test/no-plugin.css
+++ b/test/no-plugin.css
@@ -1,0 +1,3 @@
+body {
+  margin: 0;
+}


### PR DESCRIPTION
Proposal to bump the feature version.

Feature updates:
+ Add `--poll` option: https://github.com/postcss/postcss-cli/pull/39
+ Add `--log` option: https://github.com/postcss/postcss-cli/pull/22
+ Allow running without plugins: https://github.com/postcss/postcss-cli/pull/38
+ Support es6/babel default export: https://github.com/postcss/postcss-cli/pull/37

Fix updates:
+ Update some of the dependencies: https://github.com/postcss/postcss-cli/pull/28
