### PR TITLE
fail with clearer error message when reading non-existent file in watch

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,6 +152,11 @@ if (argv.watch) {
 async.forEach(inputFiles, compile, onError);
 
 function fsWatcher(entryPoints) {
+  if (entryPoints[0] === undefined) {
+    // globby expanded to nothing
+    onError.call(this, new Error('Input files not found, unable to use stdin in --watch mode'), false);
+  }
+
   var watchedFiles = entryPoints;
   var index = {}; // source files by entry point
   var opts = {};


### PR DESCRIPTION
We run PostCSS in a pipeline that relies on Sass output first. Sometimes this pipeline would fail because the Sass output hadn't yet been written (and hence postcss-cli couldn't read it), but the error message from the cli didn't really make that obvious. Open to wording on the new message.

current message:

```
> tmp@1.0.0 run /Users/tom/code/tmp
> postcss -w no-input.css

/Users/tom/code/tmp/node_modules/chokidar/index.js:578
    throw new TypeError('Non-string provided as watch path: ' + paths);
    ^

TypeError: Non-string provided as watch path:
    at FSWatcher.add (/Users/tom/code/tmp/node_modules/chokidar/index.js:578:11)
    at Object.exports.watch (/Users/tom/code/tmp/node_modules/chokidar/index.js:710:33)
    at fsWatcher (/Users/tom/code/tmp/node_modules/postcss-cli/index.js:166:37)
    at Object.<anonymous> (/Users/tom/code/tmp/node_modules/postcss-cli/index.js:149:21)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.require (module.js:498:17)
```

new message:

```
> postcss-cli/bin/postcss -w no-input.css                            ~/Code/tmp
Error: Input files not found, unable to use stdin in --watch mode
    at fsWatcher (/Users/tom/code/tmp/postcss-cli/index.js:157:24)
    at Object.<anonymous> (/Users/tom/code/tmp/postcss-cli/index.js:149:21)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/tom/code/tmp/postcss-cli/bin/postcss:3:1)
```
