### PR TITLE
Add tests for common config

### DIFF
--- a/.cleanup.js
+++ b/.cleanup.js
@@ -1,0 +1,1 @@
+require('fs-promise').emptyDir('test/fixtures/.tmp/')

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Test artifacts
+.tmp
+
 # Logs
 logs
 *.log

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "test": "ava",
+    "posttest": "node .cleanup.js",
     "lint": "standard"
   },
   "repository": "https://github.com/postcss/postcss-cli.git",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
   "devDependencies": {
     "ava": "^0.17.0",
     "standard": "^8.4.0",
-    "tempfile": "^1.1.1"
+    "uuid": "^3.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "ava": "^0.17.0",
+    "postcss-import": "^9.0.0",
     "standard": "^8.4.0",
     "uuid": "^3.0.1"
   }

--- a/test/config.js
+++ b/test/config.js
@@ -1,0 +1,25 @@
+import test from 'ava'
+import path from 'path'
+import createEnv from './helpers/create-config-env.js'
+import run from './helpers/run-cli.js'
+import read from './helpers/readFile.js'
+
+test('supports common config', async function (t) {
+  var env = `module.exports = {
+    plugins: [
+      require('postcss-import')()
+    ]
+  }`
+  var dir = await createEnv(env, ['*a-red.css'])
+  var { error } = await run(['imports-a-red.css', '-o', 'out.css'], dir)
+  t.ifError(error)
+  t.is(await read(path.join(dir, 'out.css')), await read('test/fixtures/a-red.css'))
+})
+
+test("doesn't error on empty config", async function (t) {
+  var env = `module.exports = {}`
+  var dir = await createEnv(env, ['a-red.css'])
+  var { error } = await run(['a-red.css', '-o', 'out.css'], dir)
+  t.ifError(error)
+  t.is(await read(path.join(dir, 'out.css')), await read('test/fixtures/a-red.css'))
+})

--- a/test/fixtures/imports-a-red.css
+++ b/test/fixtures/imports-a-red.css
@@ -1,0 +1,1 @@
+@import "./a-red.css";

--- a/test/helpers/create-config-env.js
+++ b/test/helpers/create-config-env.js
@@ -1,0 +1,21 @@
+const fs = require('fs-promise')
+const path = require('path')
+const globby = require('globby')
+const tmp = require('./get-tmp.js')
+
+module.exports = function (conf, fixtures) {
+  if (!fixtures) fixtures = '**/*'
+  // fixtures = fixtures.map(p => path.join('test/fixtures', p))
+  var dir = tmp()
+  // Save promise in a var
+  var fixtureCopy = globby(fixtures, {cwd: 'test/fixtures'})
+  .then(list => {
+    return list.map(item => {
+      return fs.copy(path.join('test/fixtures', item), path.join(dir, item))
+    })
+  })
+  // Save promise in a var
+  var confWrite = fs.outputFile(path.join(dir, 'postcss.config.js'), conf)
+  // Return a promise for dir when both tasks are done:
+  return Promise.all([fixtureCopy, confWrite]).then(() => dir)
+}

--- a/test/helpers/get-tmp.js
+++ b/test/helpers/get-tmp.js
@@ -1,0 +1,6 @@
+const path = require('path')
+const uuid = require('uuid')
+module.exports = (ext) => {
+  if (!ext) ext = ''
+  return path.join('test/fixtures/.tmp', uuid()) + ext
+}

--- a/test/helpers/readFile.js
+++ b/test/helpers/readFile.js
@@ -1,0 +1,5 @@
+const fs = require('fs-promise')
+
+module.exports = function (path) {
+  return fs.readFile(path, 'utf8')
+}

--- a/test/helpers/run-cli.js
+++ b/test/helpers/run-cli.js
@@ -1,9 +1,10 @@
 'use strict'
+const path = require('path')
 const execFile = require('child_process').execFile
 
-module.exports = function (args) {
+module.exports = function (args, cwd) {
   return new Promise(function (resolve) {
-    execFile('bin/postcss', args, function (error, stdout, stderr) {
+    execFile(path.resolve('bin/postcss'), args, {cwd}, function (error, stdout, stderr) {
       resolve({
         code: error && error.code ? error.code : 0,
         error,

--- a/test/postcss-cli.js
+++ b/test/postcss-cli.js
@@ -1,12 +1,8 @@
 import test from 'ava'
 import run from './helpers/run-cli.js'
-import fs from 'fs-promise'
+import read from './helpers/readFile.js'
 import path from 'path'
-import tmp from 'tempfile'
-
-function read (path) {
-  return fs.readFile(path, 'utf8')
-}
+import tmp from './helpers/get-tmp.js'
 
 test('works without plugins or config', async function (t) {
   var out = tmp('.css')


### PR DESCRIPTION
Also refactored tests and helpers.

Tests are now written to a `.tmp` directory in `test/fixtures` instead of the OS tempdir. This is needed so we can `require` plugins from the common config.