### PR TITLE
Fix watch's glob handling, modify tests to cover this case

### DIFF
--- a/index.js
+++ b/index.js
@@ -176,7 +176,9 @@ Promise.resolve()
       error('Must use --dir or --replace with multiple input files')
     }
 
-    return files(i)
+    input = i
+
+    return files(input)
   })
   .then((results) => {
     if (argv.watch) {

--- a/test/watch.js
+++ b/test/watch.js
@@ -2,7 +2,7 @@ import test from 'ava'
 
 import fs from 'fs-promise'
 import path from 'path'
-import { execFile } from 'child_process'
+import { exec, execFile } from 'child_process'
 import chokidar from 'chokidar'
 
 import ENV from './helpers/env.js'
@@ -44,17 +44,11 @@ test.cb('--watch works', function (t) {
 
       // Start postcss-cli:
       watcher.on('ready', () => {
-        cp = execFile(
-          path.resolve('bin/postcss'),
-          [
-            'a.css',
-            '-o', 'output.css',
-            '-w',
-            '--no-map'
-          ],
+        // Using exec() and quoting "*.css" to test watch's glob handling:
+        cp = exec(
+          `${path.resolve('bin/postcss')} "*.css" -o output.css --no-map -w`,
           { cwd: dir }
         )
-
         cp.on('error', t.end)
         cp.on('exit', code => { if (code) t.end(code) })
       })


### PR DESCRIPTION
watch's logic used the unexpanded glob input file list. This caused errors on Windows. Now, we mutate the global input variable to contain the expanded globs.

Fixes #95

@michael-ciniawsky?