### PR TITLE
Improve incremental rebuild; use absolute paths internally

### DIFF
--- a/lib/depGraph.js
+++ b/lib/depGraph.js
@@ -1,0 +1,21 @@
+const path = require('path')
+const DepGraph = require('dependency-graph').DepGraph
+
+const graph = new DepGraph()
+
+exports.add = message => {
+  message.parent = path.resolve(message.parent)
+  message.file = path.resolve(message.file)
+
+  graph.addNode(message.parent)
+  graph.addNode(message.file)
+  graph.addDependency(message.parent, message.file)
+  return message
+}
+
+exports.dependantsOf = node => {
+  node = path.resolve(node)
+
+  if (graph.hasNode(node)) return graph.dependantsOf(node)
+  return []
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "chokidar": "^1.6.1",
+    "dependency-graph": "^0.5.0",
     "fs-promise": "^1.0.0",
     "get-stdin": "^5.0.1",
     "globby": "^6.1.0",


### PR DESCRIPTION
This incremental rebuild is much smarter. Also fixed edge case where a file is both a dependency and an entry point.

Using absolute paths internally is a must for reliable smart rebuilding (dependency messages can contain absolute paths). We are calculating the relative path for presentation to the user.

Attn @michael-ciniawsky for review.