### PR TITLE
Don't share global options object for calls to PostCSS

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,7 +177,7 @@ function css(css, file) {
 
   return rc(ctx, argv.config)
     .then(() => {
-      const options = config.options
+      const options = Object.assign({}, config.options)
 
       if (file === 'stdin' && output) file = output
 


### PR DESCRIPTION
The fields "to" and "from" is set in a global options object for each processed css file. After postcss is finished the chained function that writes the result to disk might get totally different values for "to" and "from" thus writing the css to the wrong file.

I clone the options object using Object.assign to avoid this.