### PR TITLE
Writing spinner to STDOUT when it is free

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,8 @@ const output = argv.output
 
 if (argv.map) argv.map = { inline: false }
 
-const spinner = ora({ stream: process.stdout })
+const cssToStdout = output || dir || argv.replace;
+const spinner = ora({ stream: cssToStdout ? process.stderr : process.stdout })
 
 let config = {
   options: {

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ const output = argv.output
 
 if (argv.map) argv.map = { inline: false }
 
-const spinner = ora()
+const spinner = ora({ stream: process.stdout })
 
 let config = {
   options: {

--- a/index.js
+++ b/index.js
@@ -26,7 +26,9 @@ const output = argv.output
 if (argv.map) argv.map = { inline: false }
 
 const stdoutIsFree = output || dir || argv.replace
-const spinner = ora({ stream: stdoutIsFree ? process.stdout : process.stderr })
+const spinnerStream =
+  argv.stdout && stdoutIsFree ? process.stdout : process.stderr
+const spinner = ora({ stream: spinnerStream })
 
 let config = {
   options: {
@@ -61,6 +63,10 @@ Promise.resolve()
 
     if (argv.watch) {
       error('Input Error: Cannot run in watch mode when reading from stdin')
+    }
+
+    if (argv.stdout && !stdoutIsFree) {
+      error('Input Error: Cannot use --stdout when outputing to stdout')
     }
 
     return ['stdin']

--- a/index.js
+++ b/index.js
@@ -25,8 +25,8 @@ const output = argv.output
 
 if (argv.map) argv.map = { inline: false }
 
-const cssToStdout = output || dir || argv.replace;
-const spinner = ora({ stream: cssToStdout ? process.stderr : process.stdout })
+const stdoutIsFree = !output && !dir && !argv.replace
+const spinner = ora({ stream: stdoutIsFree ? process.stdout : process.stderr })
 
 let config = {
   options: {

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ const output = argv.output
 
 if (argv.map) argv.map = { inline: false }
 
-const stdoutIsFree = !output && !dir && !argv.replace
+const stdoutIsFree = output || dir || argv.replace
 const spinner = ora({ stream: stdoutIsFree ? process.stdout : process.stderr })
 
 let config = {

--- a/lib/args.js
+++ b/lib/args.js
@@ -33,6 +33,11 @@ Usage:
 
   $0 [input.css] [OPTIONS] [--output|-o output.css] [--watch]`
   )
+  .option('l', {
+    alias: 'stdout',
+    desc: 'Print log output to stdout',
+    type: 'boolean'
+  })
   .option('o', {
     alias: 'output',
     desc: 'Output file',


### PR DESCRIPTION
This change allows for more useful parsing of postcss-cli output.

For example, only writing errors to STDERR allows a consumer to add highlighting based on which stream the message is written to.

![image](https://user-images.githubusercontent.com/647452/33343545-88bbb8b0-d43a-11e7-96cb-2721776a693e.png)

Printing non-errors to STDERR is awkward, in this scenario.

![image](https://user-images.githubusercontent.com/647452/33343639-f0a5bc32-d43a-11e7-8607-f40fe312c079.png)
