### PR TITLE
Fixing --watch not working with --replace

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,12 +97,10 @@ Promise.resolve()
           console.warn(chalk.bold.cyan('Waiting for file changes...'))
         })
         .on('change', file => {
-          if (argv.replace) {
-            if (file in updatingFiles) {
-              delete updatingFiles[file]
-              console.warn(chalk.bold.cyan('Ignoring change to busy file'))
-              return
-            }
+          if (file in updatingFiles) {
+            delete updatingFiles[file]
+            console.warn(chalk.bold.cyan('Ignoring change to busy file'))
+            return
           }
           let recompile = []
 
@@ -221,7 +219,7 @@ function css(css, file) {
           const tasks = []
 
           if (options.to) {
-            if (argv.replace) {
+            if (options.to === options.from) {
               updatingFiles[options.to] = true
             }
 

--- a/index.js
+++ b/index.js
@@ -48,6 +48,8 @@ let config = {
 if (argv.env) process.env.NODE_ENV = argv.env
 if (argv.config) argv.config = path.resolve(argv.config)
 
+const updatingFiles = {}
+
 Promise.resolve()
   .then(() => {
     if (input && input.length) return globber(input)
@@ -83,7 +85,6 @@ Promise.resolve()
   })
   .then(results => {
     if (argv.watch) {
-      const updatingFiles = {}
       const watcher = chokidar.watch(input.concat(dependencies(results)), {
         usePolling: argv.poll,
         interval: argv.poll && typeof argv.poll === 'number' ? argv.poll : 100
@@ -102,7 +103,6 @@ Promise.resolve()
               console.warn(chalk.bold.cyan('Ignoring change to busy file'))
               return
             }
-            updatingFiles[file] = true
           }
           let recompile = []
 
@@ -221,6 +221,10 @@ function css(css, file) {
           const tasks = []
 
           if (options.to) {
+            if (argv.replace) {
+              updatingFiles[options.to] = true
+            }
+
             tasks.push(fs.outputFile(options.to, result.css))
 
             if (result.map) {

--- a/index.js
+++ b/index.js
@@ -219,7 +219,7 @@ function css(css, file) {
           const tasks = []
 
           if (options.to) {
-            if (options.to === options.from) {
+            if (argv.watch && options.to === options.from) {
               updatingFiles[options.to] = true
             }
 


### PR DESCRIPTION
To get `--watch` to work with the `--replace` option, I'm tracking which files are currently updating and skipping the next change notification received for that file.

So far, this has worked perfectly for me on a Mac.

Fixes #126