### PR TITLE
Fixing postcss not exiting with the proper exit code in --watch

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,6 +116,7 @@ Promise.resolve()
   })
   .catch(err => {
     error(err)
+
     process.exit(1)
   })
 

--- a/index.js
+++ b/index.js
@@ -114,7 +114,10 @@ Promise.resolve()
         })
     }
   })
-  .catch(error)
+  .catch(err => {
+    error(err)
+    process.exit(1)
+  })
 
 function rc(ctx, path) {
   if (argv.use) return Promise.resolve()


### PR DESCRIPTION
When running `postcss --watch`, if an error is encountered during the first pass postcss currently exits with an exit code of 0. The reason this is happening is because the error function specifically doesn't call `process.exit(1)` in watch mode. 