### PR TITLE
fixes issue with maps flag not working

### DIFF
--- a/index.js
+++ b/index.js
@@ -153,7 +153,11 @@ function files(files) {
 }
 
 function css(css, file) {
-  const ctx = { options: config.options }
+  // XXX: cli arguments seem to be handled differently in different environments
+  // therefore explicitly copy options up to main ctx (particularly the --map setting which is needed by the postcss process function)
+  const ctx = Object.assign({}, config.options)
+  // now copy the options object onto the ctx to preserve functionality down line
+  ctx.options = config.options
 
   if (file !== 'stdin') {
     ctx.file = {


### PR DESCRIPTION
Cli arguments seem to be handled differently in different environments. From within the tests (using execFile) all is well (therefore they're passing), however when using a standard cli (zsh) the structure of the options looks very different. Do a dump of options while running tests (index.js ~:189ish after options is set) and you'll see that the maps key is present when the `-m` flag is set. However, if you run postcss as a package from a project, you'll see that the maps key is now missing. 

The main problem is the missing "maps" key when sending the options object to the `process` method. Not wanting to make too big of a change I copied the options object back on the the `ctx` object to avoid any problems.

All tests are passing except 'error invalid --config' but that appears to be a pre-existing issue. 