### PR TITLE
fix tests on Windows

### DIFF
--- a/test/base.js
+++ b/test/base.js
@@ -9,7 +9,7 @@ test('--base --dir works', async t => {
   const dir = tmp()
 
   const { error, stderr } = await cli([
-    'test/fixtures/base/**/*.css',
+    '"test/fixtures/base/**/*.css"',
     '--dir',
     dir,
     '--base',

--- a/test/helpers/cli.js
+++ b/test/helpers/cli.js
@@ -1,11 +1,10 @@
 import path from 'path'
-import { execFile } from 'child_process'
+import { exec } from 'child_process'
 
 export default function(args, cwd) {
   return new Promise(resolve => {
-    execFile(
-      path.resolve('bin/postcss'),
-      args,
+    exec(
+      `node ${path.resolve('bin/postcss')} ${args.join(' ')}`,
       { cwd },
       (err, stdout, stderr) => {
         resolve({

--- a/test/helpers/read.js
+++ b/test/helpers/read.js
@@ -1,5 +1,5 @@
 import { readFile } from 'fs-extra'
 
 export default function(path) {
-  return readFile(path, 'utf8')
+  return readFile(path, 'utf8').then(content => content.replace(/\r\n/g, '\n')) // normalize line endings on Windows
 }

--- a/test/stdin.js
+++ b/test/stdin.js
@@ -2,7 +2,7 @@ import test from 'ava'
 
 import fs from 'fs-extra'
 import path from 'path'
-import { execFile } from 'child_process'
+import { exec } from 'child_process'
 
 import tmp from './helpers/tmp.js'
 import read from './helpers/read.js'
@@ -10,9 +10,8 @@ import read from './helpers/read.js'
 test.cb('reads from stdin', t => {
   const output = tmp('output.css')
 
-  const cp = execFile(
-    path.resolve('bin/postcss'),
-    ['-o', output, '--no-map'],
+  const cp = exec(
+    `node ${path.resolve('bin/postcss')} -o ${output} --no-map`,
     (error, stdout, stderr) => {
       if (error) t.end(error, stderr)
 

--- a/test/stdout.js
+++ b/test/stdout.js
@@ -2,18 +2,19 @@ import test from 'ava'
 
 import fs from 'fs-extra'
 import path from 'path'
-import { execFile } from 'child_process'
+import { exec } from 'child_process'
 
 import read from './helpers/read.js'
 
 test.cb('writes to stdout', t => {
-  const cp = execFile(
-    path.resolve('bin/postcss'),
-    ['--parser', 'sugarss', '-u', 'postcss-import', '--no-map'],
+  const cp = exec(
+    `node ${path.resolve(
+      'bin/postcss'
+    )} --parser sugarss -u postcss-import --no-map`,
     (error, stdout, stderr) => {
       if (error) t.end(error, stderr)
 
-      Promise.all([stdout, read('test/fixtures/s.css')])
+      Promise.all([stdout.replace(/\r\n/g, '\n'), read('test/fixtures/s.css')])
         .then(([a, e]) => {
           t.is(a, e)
           t.end()

--- a/test/watch.js
+++ b/test/watch.js
@@ -2,7 +2,7 @@ import test from 'ava'
 
 import fs from 'fs-extra'
 import path from 'path'
-import { exec, execFile } from 'child_process'
+import { exec } from 'child_process'
 import chokidar from 'chokidar'
 
 import ENV from './helpers/env.js'
@@ -48,7 +48,9 @@ test.cb.skip('--watch works', t => {
       watcher.on('ready', () => {
         // Using exec() and quoting "*.css" to test watch's glob handling:
         cp = exec(
-          `${path.resolve('bin/postcss')} "*.css" -o output.css --no-map -w`,
+          `node ${path.resolve(
+            'bin/postcss'
+          )} "*.css" -o output.css --no-map -w`,
           { cwd: dir }
         )
         cp.on('error', t.end)
@@ -124,9 +126,10 @@ test.cb.skip('--watch postcss.config.js', t => {
 
       // Start postcss-cli:
       watcher.on('ready', () => {
-        cp = execFile(
-          path.resolve('bin/postcss'),
-          ['import.css', '-o', 'output.css', '-w', '--no-map'],
+        cp = exec(
+          `node ${path.resolve(
+            'bin/postcss'
+          )} import.css -o output.css -w --no-map`,
           { cwd: dir }
         )
 
@@ -193,17 +196,10 @@ test.cb.skip('--watch dependencies', t => {
 
       // Start postcss-cli:
       watcher.on('ready', () => {
-        cp = execFile(
-          path.resolve('bin/postcss'),
-          [
-            'import.css',
-            '-o',
-            'output.css',
-            '-u',
-            'postcss-import',
-            '-w',
-            '--no-map'
-          ],
+        cp = exec(
+          `node ${path.resolve(
+            'bin/postcss'
+          )} import.css -o output.css -u postcss-import -w --no-map`,
           { cwd: dir }
         )
 
@@ -252,9 +248,8 @@ test.cb.skip("--watch doesn't exit on CssSyntaxError", t => {
       })
 
       let killed = false
-      const cp = execFile(
-        path.resolve('bin/postcss'),
-        ['a.css', '-o', 'output.css', '-w', '--no-map'],
+      const cp = exec(
+        `node ${path.resolve('bin/postcss')} a.css -o output.css -w --no-map`,
         { cwd: dir }
       )
       cp.on('error', t.end)


### PR DESCRIPTION
fix for #164 

- I replace `execFile` by `exec` with an explicit call to `node`, which is required on Windows
- I fixed some issues with CRLF with basic replace `\r\n` here and there

cc @RyanZim 