### PR TITLE
Added the --rename option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Basic options:
   -o, --output   Output file                                            [string]
   -d, --dir      Output directory                                       [string]
   -r, --replace  Replace (overwrite) the input file                    [boolean]
+  --rename       Rename the output file                                 [string]
   --map, -m      Create an external sourcemap
   --no-map       Disable the default inline sourcemaps
   --verbose      Be verbose                                            [boolean]
@@ -62,10 +63,10 @@ Examples:
   postcss src/**/*.css --base src --dir build           Glob Pattern & output
   cat input.css | postcss -u autoprefixer > output.css  Piping input & output
 
-If no input files are passed, it reads from stdin. If neither -o, --dir, or
---replace is passed, it writes to stdout.
+If no input files are passed, it reads from stdin. If neither -o, --dir, --replace
+or --rename is passed, it writes to stdout.
 
-If there are multiple input files, the --dir or --replace option must be passed.
+If there are multiple input files, the --dir, --replace or --rename option must be passed.
 
 Input files may contain globs (e.g. src/**/*.css). If you pass an input directory, it will process
 all files in the directory and any subdirectories, respecting the glob pattern.

--- a/index.js
+++ b/index.js
@@ -50,14 +50,14 @@ if (argv.config) argv.config = path.resolve(argv.config)
 
 Promise.resolve()
   .then(() => {
-    if (argv.watch && !(argv.output || argv.replace || argv.dir)) {
+    if (argv.watch && !(argv.output || argv.replace || argv.rename || argv.dir)) {
       error('Cannot write to stdout in watch mode')
     }
     if (input && input.length) return globber(input)
 
-    if (argv.replace || argv.dir) {
+    if (argv.replace || argv.rename || argv.dir) {
       error(
-        'Input Error: Cannot use --dir or --replace when reading from stdin'
+        'Input Error: Cannot use --dir, --replace or --rename when reading from stdin'
       )
     }
 
@@ -72,9 +72,9 @@ Promise.resolve()
       error('Input Error: You must pass a valid list of files to parse')
     }
 
-    if (i.length > 1 && !argv.dir && !argv.replace) {
+    if (i.length > 1 && !argv.dir && !argv.replace && !argv.rename ) {
       error(
-        'Input Error: Must use --dir or --replace with multiple input files'
+        'Input Error: Must use --dir, --replace or --rename with multiple input files'
       )
     }
 
@@ -190,11 +190,20 @@ function css(css, file) {
       // TODO: Unit test this
       options.from = file === 'stdin' ? path.join(process.cwd(), 'stdin') : file
 
-      if (output || dir || argv.replace) {
+      if (output || dir || argv.replace || argv.rename) {
         const base = argv.base
           ? file.replace(path.resolve(argv.base), '')
           : path.basename(file)
-        options.to = output || (argv.replace ? file : path.join(dir, base))
+
+        if (output) {
+          options.to = output;
+        } else if (argv.replace) {
+          options.to = file;
+        } else if (argv.rename) {
+          options.to = path.join(dir ? dir : path.dirname(file), argv.rename);
+        } else {
+          options.to = path.join(dir, base);
+        }
 
         if (argv.ext) {
           options.to = options.to.replace(path.extname(options.to), argv.ext)

--- a/lib/args.js
+++ b/lib/args.js
@@ -37,7 +37,7 @@ Usage:
   $0 <input.css>... [OPTIONS] --replace`
   )
   .group(
-    ['o', 'd', 'r', 'map', 'no-map', 'verbose', 'watch', 'env'],
+    ['o', 'd', 'r', 'rename', 'map', 'no-map', 'verbose', 'watch', 'env'],
     'Basic options:'
   )
   .option('o', {
@@ -57,6 +57,11 @@ Usage:
     desc: 'Replace (overwrite) the input file',
     type: 'boolean',
     conflicts: ['output', 'dir']
+  })
+  .option('rename', {
+    desc: 'Rename the output file',
+    type: 'string',
+    conflicts: ['replace', 'output']
   })
   .alias('map', 'm')
   .describe('map', 'Create an external sourcemap')

--- a/test/error.js
+++ b/test/error.js
@@ -6,14 +6,20 @@ import cli from './helpers/cli.js'
 test('multiple input files && --output', t => {
   return cli(['test/fixtures/*.css', '-o', tmp()]).then(({ err, code }) => {
     t.is(code, 1, 'expected non-zero error code')
-    t.regex(err.toString(), /Input Error: Must use --dir or --replace/)
+    t.regex(
+      err.toString(),
+      /Input Error: Must use --dir, --replace or --rename/
+    )
   })
 })
 
 test('multiple input files && writing to stdout', t => {
   return cli(['test/fixtures/*.css']).then(({ err, code }) => {
     t.is(code, 1, 'expected non-zero error code')
-    t.regex(err.toString(), /Input Error: Must use --dir or --replace/)
+    t.regex(
+      err.toString(),
+      /Input Error: Must use --dir, --replace or --rename/
+    )
   })
 })
 

--- a/test/rename.js
+++ b/test/rename.js
@@ -1,0 +1,54 @@
+import test from 'ava'
+
+import fs from 'fs-extra'
+import path from 'path'
+
+import cli from './helpers/cli.js'
+import tmp from './helpers/tmp.js'
+import read from './helpers/read.js'
+
+test('--rename works', async t => {
+  const dir = tmp()
+
+  const output = path.join(dir, 'output.css')
+
+  await Promise.all([fs.copy('test/fixtures/a.css', path.join(dir, 'a.css'))])
+
+  // XXX: Should be able to pass output instead of dir here, but this test env is weird
+  const { error, stderr } = await cli([
+    dir,
+    '--rename',
+    'output.js',
+    '-u',
+    'postcss-import',
+    '--no-map'
+  ])
+
+  t.ifError(error, stderr)
+
+  t.is(await read(output), await read('test/fixtures/a.css'))
+})
+
+test('--rename works with --dir', async t => {
+  const dir = tmp()
+
+  const output = path.join(dir, 'foo', 'output.css')
+
+  await fs.copy('test/fixtures/a.css', path.join(dir, 'a.css'))
+
+  // XXX: Should be able to pass output instead of dir here, but this test env is weird
+  const { error, stderr } = await cli([
+    dir,
+    '--rename',
+    'output.js',
+    '--dir',
+    'foo',
+    '-u',
+    'postcss-import',
+    '--no-map'
+  ])
+
+  t.ifError(error, stderr)
+
+  t.is(await read(output), await read('test/fixtures/foo/a.css'))
+})


### PR DESCRIPTION
This pull requests adds a new `--rename` option. 

The idea is to be able to transform multiple files and store them in the same directory as the source, but not to replace the source file.

A possible use case would be the following:

```
postcss site/plugins/*/index.modules.css --rename index.js
```

This would parse all the `index.modules.css` files, transform them and store them in their original directory with the name `index.js`.

This can also be combined with the `--dir` option:

```
postcss site/plugins/*/index.modules.css --dir dist --rename index.js
```

This would keep the original directory structure inside the destination directory, but rename all the files to `index.js` (and not `index.modules.js`).