### PR TITLE
Add --dot option to allow globby to match files/dir that begin with a '.'

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,15 @@ Usage:
   postcss <input.css>... [OPTIONS] --replace
 
 Basic options:
-  -o, --output   Output file                                            [string]
-  -d, --dir      Output directory                                       [string]
-  -r, --replace  Replace (overwrite) the input file                    [boolean]
-  --map, -m      Create an external sourcemap
-  --no-map       Disable the default inline sourcemaps
-  --verbose      Be verbose                                            [boolean]
-  --watch, -w    Watch files for changes and recompile as needed       [boolean]
-  --env          A shortcut for setting NODE_ENV                        [string]
+  -o, --output        Output file                                            [string]
+  -d, --dir           Output directory                                       [string]
+  -r, --replace       Replace (overwrite) the input file                    [boolean]
+  --map, -m           Create an external sourcemap
+  --no-map            Disable the default inline sourcemaps
+  --verbose           Be verbose                                            [boolean]
+  --watch, -w         Watch files for changes and recompile as needed       [boolean]
+  --env               A shortcut for setting NODE_ENV                        [string]
+  --include-dotfiles  Enables glob to match files/dirs that begin with "."  [boolean]
 
 Options for when not using a config file:
   -u, --use      List of postcss plugins to use                          [array]

--- a/index.js
+++ b/index.js
@@ -53,7 +53,10 @@ Promise.resolve()
     if (argv.watch && !(argv.output || argv.replace || argv.dir)) {
       error('Cannot write to stdout in watch mode')
     }
-    if (input && input.length) return globber(input)
+
+    if (input && input.length) {
+      return globber(input, { dot: argv.includeDotfiles })
+    }
 
     if (argv.replace || argv.dir) {
       error(

--- a/lib/args.js
+++ b/lib/args.js
@@ -58,6 +58,10 @@ Usage:
     type: 'boolean',
     conflicts: ['output', 'dir']
   })
+  .option('include-dotfiles', {
+    desc: 'Enables glob to match files/dirs that begin with "."',
+    type: 'boolean'
+  })
   .alias('map', 'm')
   .describe('map', 'Create an external sourcemap')
   .describe('no-map', 'Disable the default inline sourcemaps')


### PR DESCRIPTION
Background: https://github.com/isaacs/node-glob\#dots

My use case is I was trying to use a glob but it would not match the directory I used which begins with a `.`.

For example:

```bash
postcss "src/**/.sass-cache/*" --use autoprefixer --replace
```

This PR will pass the `dot` option to `globby` which is used by [`fast-glob`](https://github.com/mrmlnc/fast-glob#dot). Here is what it will look like practically:

```bash
postcss "src/**/.sass-cache/*" --dot --use autoprefixer --replace
```

If user does not pass `--dot` nothing will change 😄 Please let me know if anything needs to be changed. Thanks for all the postcss crew does by the way. This tool is amazing!!!
