### PR TITLE
Update globby to v9.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dependency-graph": "^0.8.0",
     "fs-extra": "^7.0.0",
     "get-stdin": "^6.0.0",
-    "globby": "^8.0.0",
+    "globby": "^9.0.0",
     "postcss": "^7.0.0",
     "postcss-load-config": "^2.0.0",
     "postcss-reporter": "^6.0.0",


### PR DESCRIPTION
Breaking changes were:
* Require Node.js 6 and upgrade dependencies
* Rename the opts property returned from .generateGlobTasks to options

Fixes: https://github.com/postcss/postcss-cli/issues/265