### PR TITLE
fix: respect map.annotation string

### DIFF
--- a/index.js
+++ b/index.js
@@ -222,7 +222,7 @@ function css(css, file) {
             tasks.push(fs.outputFile(options.to, result.css))
 
             if (result.map) {
-              const mapfile = getMapfile(options.to)
+              const mapfile = getMapfile(options)
               tasks.push(fs.outputFile(mapfile, result.map))
             }
           } else process.stdout.write(result.css, 'utf8')

--- a/lib/getMapfile.js
+++ b/lib/getMapfile.js
@@ -1,4 +1,8 @@
 'use strict'
-module.exports = function getMapfile(p) {
-  return `${p}.map`
+const path = require('path')
+module.exports = function getMapfile(options) {
+  if (options.map && typeof options.map.annotation === 'string') {
+    return path.join(path.dirname(options.to), options.map.annotation)
+  }
+  return `${options.to}.map`
 }

--- a/lib/getMapfile.js
+++ b/lib/getMapfile.js
@@ -2,7 +2,7 @@
 const path = require('path')
 module.exports = function getMapfile(options) {
   if (options.map && typeof options.map.annotation === 'string') {
-    return `${ path.dirname(options.to) }/${ options.map.annotation }`
+    return `${path.dirname(options.to)}/${options.map.annotation}`
   }
   return `${options.to}.map`
 }

--- a/lib/getMapfile.js
+++ b/lib/getMapfile.js
@@ -2,7 +2,7 @@
 const path = require('path')
 module.exports = function getMapfile(options) {
   if (options.map && typeof options.map.annotation === 'string') {
-    return path.join(path.dirname(options.to), options.map.annotation)
+    return `${ path.dirname(options.to) }/${ options.map.annotation }`
   }
   return `${options.to}.map`
 }

--- a/test/map.js
+++ b/test/map.js
@@ -59,16 +59,20 @@ test('--no-map disables internal sourcemaps', async t => {
 test('mapFile path is property resolved', async t => {
   const paths = [
     {
-      input: '/foo/bar.css/baz/index.css',
+      input: { to: '/foo/bar.css/baz/index.css' },
       want: '/foo/bar.css/baz/index.css.map'
     },
     {
-      input: '/foo/bar.sss/baz/index.sss',
+      input: { to: '/foo/bar.sss/baz/index.sss' },
       want: '/foo/bar.sss/baz/index.sss.map'
     },
     {
-      input: '/foo/bar.css/baz/bar.css',
+      input: { to: '/foo/bar.css/baz/bar.css' },
       want: '/foo/bar.css/baz/bar.css.map'
+    },
+    {
+      input: { map: { annotation: 'foo.map' }, to: '/foo/bar.css/baz/bar.css' },
+      want: '/foo/bar.css/baz/foo.map'
     }
   ]
 


### PR DESCRIPTION
As per the [PostCSS docs on sourcemaps](https://github.com/postcss/postcss/blob/master/docs/source-maps.md) the `opts.map.annotation` option can be set to a string, to write a manually named sourcemap file:

> * `annotation` boolean or string: indicates that PostCSS should add annotation
>   comments to the CSS. By default, PostCSS will always add a comment with a path
>   to the source map. PostCSS will not add annotations to CSS files that
>   do not contain any comments.
> 
>   By default, PostCSS presumes that you want to save the source map as
>   `opts.to + '.map'` and will use this path in the annotation comment.
>   A different path can be set by providing a string value for `annotation`.
> 
>   If you have set `inline: true`, annotation cannot be disabled.

This PR fixes PostCSS-cli to acknowledge this option, and refactors `getMapfile` to return `opts.map.annotation` if the option is set to a string.