### PR TITLE
Use 'slash' on input files before globbing to support absolute paths with backslashes on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const stdin = require('get-stdin')
 const read = require('read-cache')
 const chalk = require('chalk')
 const globber = require('globby')
+const slash = require('slash')
 const chokidar = require('chokidar')
 
 const postcss = require('postcss')
@@ -57,7 +58,7 @@ Promise.resolve()
     }
 
     if (input && input.length) {
-      return globber(input, { dot: argv.includeDotfiles })
+      return globber(input.map(slash), { dot: argv.includeDotfiles })
     }
 
     if (argv.replace || argv.dir) {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "postcss-reporter": "^7.0.0",
     "pretty-hrtime": "^1.0.3",
     "read-cache": "^1.0.0",
+    "slash": "^3.0.0",
     "yargs": "^16.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
globby (used to glob input arguments to postcss-cli) only supports forward slashes.
In order to be able to provide absolute paths containing backslashes to the CLI on Windows, they need to be converted to forward slashes, otherwise postcss-cli terminates with the error message 'Input Error: You must pass a valid list of files to parse'.