### PR TITLE
exit watch process on EOF / Ctrl-D

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,11 @@ let configFile
 if (argv.env) process.env.NODE_ENV = argv.env
 if (argv.config) argv.config = path.resolve(argv.config)
 
+if (argv.watch) {
+  process.stdin.on('end', () => process.exit(0))
+  process.stdin.resume()
+}
+
 Promise.resolve()
   .then(() => {
     if (argv.watch && !(argv.output || argv.replace || argv.dir)) {
@@ -92,9 +97,6 @@ Promise.resolve()
   })
   .then((results) => {
     if (argv.watch) {
-      process.stdin.on('end', () => process.exit(0))
-      process.stdin.resume()
-
       const printMessage = () =>
         printVerbose(chalk.dim('\nWaiting for file changes...'))
       const watcher = chokidar.watch(input.concat(dependencies(results)), {

--- a/index.js
+++ b/index.js
@@ -92,6 +92,9 @@ Promise.resolve()
   })
   .then((results) => {
     if (argv.watch) {
+      process.stdin.on('end', () => process.exit(0))
+      process.stdin.resume()
+
       const printMessage = () =>
         printVerbose(chalk.dim('\nWaiting for file changes...'))
       const watcher = chokidar.watch(input.concat(dependencies(results)), {

--- a/test/watch.js
+++ b/test/watch.js
@@ -3,7 +3,7 @@ const test = require('ava')
 
 const fs = require('fs-extra')
 const path = require('path')
-const { exec } = require('child_process')
+const { exec, spawn } = require('child_process')
 const chokidar = require('chokidar')
 
 const ENV = require('./helpers/env.js')
@@ -284,4 +284,16 @@ testCb("--watch doesn't exit on CssSyntaxError", (t) => {
 
   // Timeout:
   setTimeout(() => t.end('test timeout'), 50000)
+})
+
+testCb('--watch does exit on closing stdin (Ctrl-D/EOF)', (t) => {
+  t.plan(0)
+
+  const cp = spawn(
+    `node ${path.resolve('bin/postcss')} -o output.css -w --no-map`,
+    { shell: true }
+  )
+  cp.on('error', t.end)
+  cp.on('exit', () => t.end())
+  cp.stdin.end()
 })

--- a/test/watch.js
+++ b/test/watch.js
@@ -294,6 +294,6 @@ testCb('--watch does exit on closing stdin (Ctrl-D/EOF)', (t) => {
     { shell: true }
   )
   cp.on('error', t.end)
-  cp.on('exit', () => t.end())
+  cp.on('exit', t.end)
   cp.stdin.end()
 })

--- a/test/watch.js
+++ b/test/watch.js
@@ -8,6 +8,7 @@ const chokidar = require('chokidar')
 
 const ENV = require('./helpers/env.js')
 const read = require('./helpers/read.js')
+const tmp = require('./helpers/tmp.js')
 
 // XXX: All the tests in this file are skipped on the CI; too flacky there
 const testCb = process.env.CI ? test.cb.skip : test.cb
@@ -287,13 +288,17 @@ testCb("--watch doesn't exit on CssSyntaxError", (t) => {
 })
 
 testCb('--watch does exit on closing stdin (Ctrl-D/EOF)', (t) => {
-  t.plan(0)
+  t.plan(1)
 
   const cp = spawn(
-    `node ${path.resolve('bin/postcss')} -o output.css -w --no-map`,
+    `./bin/postcss test/fixtures/a.css -o ${tmp()} -w --no-map`,
     { shell: true }
   )
+
   cp.on('error', t.end)
-  cp.on('exit', t.end)
+  cp.on('exit', (code) => {
+    t.is(code, 0)
+    t.end()
+  })
   cp.stdin.end()
 })


### PR DESCRIPTION
It's quite common to be able to exit from a running process with Ctrl-D. This also makes it possible to integrate postcss-cli in external applications as is also mentioned in this webpack PR: https://github.com/webpack/webpack/pull/1311.

I could also make it an additional flag if that is preferred.