### PR TITLE
Error when using unsupported PostCSS version (#361)

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,11 @@ if (argv.watch) {
   process.stdin.resume()
 }
 
+/* istanbul ignore next */
+if (parseInt(postcss().version) < 8) {
+  error('Please install PostCSS 8 or above')
+}
+
 Promise.resolve()
   .then(() => {
     if (argv.watch && !(argv.output || argv.replace || argv.dir)) {


### PR DESCRIPTION
Added the `postcss` version check @ai talked about. Changed the wording a bit and used the built-in `error` function.

As for testing this functionality, not going to lie. I couldn't get this error to throw ones, even did the steps mentioned in the issue (#361) by using `npm link` to this version and installing plugins that use `PostCSS 7` and it builds the CSS file and didn't throw a single error.

Seems like this error might be thrown very rarely? But I do hope it helps in the long run. 🙂