### PR TITLE
Fix PostCSS CLI logo not loading.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![chat][chat]][chat-url]
 
 <div align="center">
-  <img width="100" height="100" title="CLI" src="http://postcss.github.io/postcss-cli/logo.svg">
+  <img width="100" height="100" title="CLI" src="https://raw.githubusercontent.com/postcss/postcss-cli/HEAD/logo.svg">
   <a href="https://github.com/postcss/postcss">
     <img width="110" height="110" title="PostCSS" src="http://postcss.github.io/postcss/logo.svg" hspace="10">
   </a>


### PR DESCRIPTION
Noticed that the PostCSS CLI logo wasn't loading due to `gh-pages` not being enabled on the PostCSS CLI repository anymore. So I updated the README to grab the logo directly from the repository using the `raw.githubusercontent` URL.

Set the branch to `HEAD` in-case the master branch ever changes names to something else. 🙂

## Before

![Screen shot of README with non-loading logo](https://user-images.githubusercontent.com/2221746/101593272-f7113880-39ef-11eb-90e0-f5884fcfad7b.png)

## After

![Screen shot of README with logo](https://user-images.githubusercontent.com/2221746/101593284-fb3d5600-39ef-11eb-8b31-e1a8a5379cec.png)
