### PR TITLE
refactor: replace chalk with colorette

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const path = require('path')
 const prettyHrtime = require('pretty-hrtime')
 const stdin = require('get-stdin')
 const read = require('read-cache')
-const chalk = require('chalk')
+const { bold, dim, red, cyan, green } = require('colorette')
 const globber = require('globby')
 const slash = require('slash')
 const chokidar = require('chokidar')
@@ -106,7 +106,7 @@ Promise.resolve()
   .then((results) => {
     if (argv.watch) {
       const printMessage = () =>
-        printVerbose(chalk.dim('\nWaiting for file changes...'))
+        printVerbose(dim('\nWaiting for file changes...'))
       const watcher = chokidar.watch(input.concat(dependencies(results)), {
         usePolling: argv.poll,
         interval: argv.poll && typeof argv.poll === 'number' ? argv.poll : 100,
@@ -197,7 +197,7 @@ function css(css, file) {
 
   const time = process.hrtime()
 
-  printVerbose(chalk`{cyan Processing {bold ${relativePath}}...}`)
+  printVerbose(cyan(`Processing ${bold(relativePath)}...`))
 
   return rc(ctx, argv.config)
     .then((config) => {
@@ -245,7 +245,7 @@ function css(css, file) {
           return Promise.all(tasks).then(() => {
             const prettyTime = prettyHrtime(process.hrtime(time))
             printVerbose(
-              chalk`{green Finished {bold ${relativePath}} in {bold ${prettyTime}}}`
+              green(`Finished ${bold(relativePath)} in ${bold(prettyTime)}`)
             )
 
             const messages = result.warnings()
@@ -288,7 +288,7 @@ function error(err) {
   if (argv.verbose) console.error()
 
   if (typeof err === 'string') {
-    console.error(chalk.red(err))
+    console.error(red(err))
   } else if (err.name === 'CssSyntaxError') {
     console.error(err.toString())
   } else {

--- a/lib/args.js
+++ b/lib/args.js
@@ -1,5 +1,5 @@
 'use strict'
-const chalk = require('chalk')
+const { bold, red } = require('colorette')
 
 const logo = `
                                       /|\\
@@ -15,7 +15,7 @@ const logo = `
 
 module.exports = require('yargs')
   .usage(
-    `${chalk.bold.red(logo)}
+    `${bold(red(logo))}
 Usage:
   $0 [input.css] [OPTIONS] [-o|--output output.css] [--watch|-w]
   $0 <input.css>... [OPTIONS] --dir <output-directory> [--watch|-w]

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "test": "nyc ava -v"
   },
   "dependencies": {
-    "chalk": "^4.0.0",
     "chokidar": "^3.3.0",
+    "colorette": "^1.2.1",
     "dependency-graph": "^0.9.0",
     "fs-extra": "^9.0.0",
     "get-stdin": "^8.0.0",


### PR DESCRIPTION
Since postcss and postcss-reporter use colorette,
getting rid of chalk in this package saves about 100KB
when doing a `yarn install`.

I’ve run a few commands (`postcss`, `postcss --watch`) to check the output matches visually. We could diff programmatically a string highlighted by chalk with one highlighted by colorette, but then we would just be testing whether chalk and/or colorette got the color names right, which I assume they did.