### PR TITLE
Add support for `dir-dependency` messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -282,10 +282,10 @@ function dependencies(results) {
       )
       .map(depGraph.add)
       .forEach((dependency) => {
-        if (dependency.type === 'dependency') {
-          messages.push(dependency.file)
-        } else {
+        if (dependency.type === 'dir-dependency') {
           messages.push(dependency.dir)
+        } else {
+          messages.push(dependency.file)
         }
       })
   })

--- a/index.js
+++ b/index.js
@@ -126,8 +126,6 @@ Promise.resolve()
         const dependants = depGraph
           .dependantsOf(file)
           .concat(getAncestorDirs(file).flatMap(depGraph.dependantsOf))
-          // deduplicate
-          .filter((value, index, array) => array.indexOf(value) === index)
 
         recompile = recompile.concat(
           dependants.filter((file) => input.includes(file))
@@ -135,7 +133,7 @@ Promise.resolve()
 
         if (!recompile.length) recompile = input
 
-        return files(recompile)
+        return files([...new Set(recompile)])
           .then((results) => watcher.add(dependencies(results)))
           .then(printMessage)
           .catch(error)

--- a/lib/DependencyGraph.js
+++ b/lib/DependencyGraph.js
@@ -7,11 +7,18 @@ module.exports = function () {
   return {
     add(message) {
       message.parent = path.resolve(message.parent)
-      message.file = path.resolve(message.file)
-
       graph.addNode(message.parent)
-      graph.addNode(message.file)
-      graph.addDependency(message.parent, message.file)
+
+      if (message.type === 'dependency') {
+        message.file = path.resolve(message.file)
+        graph.addNode(message.file)
+        graph.addDependency(message.parent, message.file)
+      } else {
+        message.dir = path.resolve(message.dir)
+        graph.addNode(message.dir)
+        graph.addDependency(message.parent, message.dir)
+      }
+
       return message
     },
     dependantsOf(node) {

--- a/lib/DependencyGraph.js
+++ b/lib/DependencyGraph.js
@@ -9,14 +9,14 @@ module.exports = function () {
       message.parent = path.resolve(message.parent)
       graph.addNode(message.parent)
 
-      if (message.type === 'dependency') {
-        message.file = path.resolve(message.file)
-        graph.addNode(message.file)
-        graph.addDependency(message.parent, message.file)
-      } else {
+      if (message.type === 'dir-dependency') {
         message.dir = path.resolve(message.dir)
         graph.addNode(message.dir)
         graph.addDependency(message.parent, message.dir)
+      } else {
+        message.file = path.resolve(message.file)
+        graph.addNode(message.file)
+        graph.addDependency(message.parent, message.file)
       }
 
       return message

--- a/test/watch.js
+++ b/test/watch.js
@@ -299,3 +299,198 @@ testCb('--watch does exit on closing stdin (Ctrl-D/EOF)', (t) => {
   })
   cp.stdin.end()
 })
+
+testCb('--watch watches dependencies', (t) => {
+  let cp
+
+  t.plan(2)
+
+  ENV('', ['s.css', 'a.css', 'b.css']).then((dir) => {
+    fs.writeFile(
+      path.join(dir, 'postcss.config.js'),
+      `
+        const fs = require('fs')
+        module.exports = {
+          plugins: [
+            (root, result) => {
+              const file = '${path.resolve(dir, 'a.css')}'
+              result.messages.push({
+                plugin: 'test',
+                type: 'dependency',
+                file,
+                parent: result.opts.from,
+              })
+              root.nodes = []
+              root.append(fs.readFileSync(file, 'utf8'))
+              return root
+            }
+          ]
+        }
+      `
+    )
+      .then(() => {
+        // Init watcher:
+        const watcher = chokidar.watch('.', {
+          cwd: dir,
+          ignoreInitial: true,
+          awaitWriteFinish: true,
+        })
+
+        // On the first output:
+        watcher.on('add', (p) => {
+          // Assert, then change the source file
+          if (p === 'output.css') {
+            isEqual(p, 'test/fixtures/a.css')
+              .then(() => read('test/fixtures/b.css'))
+              .then((css) => fs.writeFile(path.join(dir, 'a.css'), css))
+              .catch(done)
+          }
+        })
+
+        // When the change is picked up:
+        watcher.on('change', (p) => {
+          if (p === 'output.css') {
+            isEqual(p, 'test/fixtures/b.css')
+              .then(() => done())
+              .catch(done)
+          }
+        })
+
+        // Start postcss-cli:
+        watcher.on('ready', () => {
+          // Using exec() and quoting "*.css" to test watch's glob handling:
+          cp = exec(
+            `node ${path.resolve(
+              'bin/postcss'
+            )} "s.css" -o output.css --no-map -w`,
+            { cwd: dir }
+          )
+          cp.on('error', t.end)
+          cp.on('exit', (code) => {
+            if (code) t.end(code)
+          })
+        })
+
+        // Helper functions:
+        function isEqual(p, expected) {
+          return Promise.all([read(path.join(dir, p)), read(expected)]).then(
+            ([a, e]) => t.is(a, e)
+          )
+        }
+
+        function done(err) {
+          try {
+            cp.kill()
+          } catch {}
+
+          t.end(err)
+        }
+      })
+      .catch(t.end)
+  })
+
+  // Timeout:
+  setTimeout(() => t.end('test timeout'), 50000)
+})
+
+testCb('--watch watches directory dependencies', (t) => {
+  let cp
+
+  t.plan(2)
+
+  ENV('', ['s.css', 'base/level-1/b.css', 'base/level-1/level-2/a.css']).then(
+    (dir) => {
+      fs.writeFile(
+        path.join(dir, 'postcss.config.js'),
+        `
+          const fs = require('fs')
+          module.exports = {
+            plugins: [
+              (root, result) => {
+                result.messages.push({
+                  plugin: 'test',
+                  type: 'dir-dependency',
+                  dir: '${path.resolve(dir, 'base')}',
+                  parent: result.opts.from,
+                })
+                root.nodes = []
+                root.append(fs.readFileSync('${path.resolve(
+                  dir,
+                  'base/level-1/level-2/a.css'
+                )}', 'utf8'))
+                return root
+              }
+            ]
+          }
+        `
+      )
+        .then(() => {
+          // Init watcher:
+          const watcher = chokidar.watch('.', {
+            cwd: dir,
+            ignoreInitial: true,
+            awaitWriteFinish: true,
+          })
+
+          // On the first output:
+          watcher.on('add', (p) => {
+            // Assert, then change the source file
+            if (p === 'output.css') {
+              isEqual(p, 'test/fixtures/base/level-1/level-2/a.css')
+                .then(() => read('test/fixtures/base/level-1/b.css'))
+                .then((css) =>
+                  fs.writeFile(
+                    path.join(dir, 'base/level-1/level-2/a.css'),
+                    css
+                  )
+                )
+                .catch(done)
+            }
+          })
+
+          // When the change is picked up:
+          watcher.on('change', (p) => {
+            if (p === 'output.css') {
+              isEqual(p, 'test/fixtures/base/level-1/b.css')
+                .then(() => done())
+                .catch(done)
+            }
+          })
+
+          // Start postcss-cli:
+          watcher.on('ready', () => {
+            // Using exec() and quoting "*.css" to test watch's glob handling:
+            cp = exec(
+              `node ${path.resolve(
+                'bin/postcss'
+              )} "s.css" -o output.css --no-map -w`,
+              { cwd: dir }
+            )
+            cp.on('error', t.end)
+            cp.on('exit', (code) => {
+              if (code) t.end(code)
+            })
+          })
+
+          // Helper functions:
+          function isEqual(p, expected) {
+            return Promise.all([read(path.join(dir, p)), read(expected)]).then(
+              ([a, e]) => t.is(a, e)
+            )
+          }
+
+          function done(err) {
+            try {
+              cp.kill()
+            } catch {}
+
+            t.end(err)
+          }
+        })
+        .catch(t.end)
+    }
+  )
+
+  // Timeout:
+  setTimeout(() => t.end('test timeout'), 50000)
+})


### PR DESCRIPTION
This PR adds support for [`dir-dependency` messages](https://github.com/postcss/postcss/pull/1580).

Directory dependencies are added to the dependency graph in the same way that files are. Chokidar accepts directories and will watch them recursively. Then, when a file changes we determine the "recompile" list by finding the dependants of each of the files ancestor directories.

Any questions or concerns let me know 👍 