### PR TITLE
Add support for glob matching when watching dir-dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -281,7 +281,11 @@ function dependencies(results) {
       .map(depGraph.add)
       .forEach((dependency) => {
         if (dependency.type === 'dir-dependency') {
-          messages.push(dependency.dir)
+          messages.push(
+            dependency.glob
+              ? path.join(dependency.dir, dependency.glob)
+              : dependency.dir
+          )
         } else {
           messages.push(dependency.file)
         }

--- a/test/fixtures/base/level-1/level-2/unrelated.md
+++ b/test/fixtures/base/level-1/level-2/unrelated.md
@@ -1,0 +1,1 @@
+Editing this file should not trigger a rebuild.


### PR DESCRIPTION
This extends #383 to pass glob information on to chokidar, with the intention of reducing outputs when unrelated files are modified.

In my test example the output should only be triggered when files matching the `glob: '**/*.css'` are modified, but not when the `unrelated.md` file is modified.

A real world example where I thought watching a whole directory without applying the glob could be problematic, would be a full stack project where tailwind checks backend templates by file type for purging:

```js
  {
    plugin: 'tailwindcss',
    parent: '/home/1st8/sample_phoenix_project/assets/css/app.css',
    type: 'dir-dependency',
    dir: '/home/1st8/sample_phoenix_project',
    glob: '**/*.heex'
  }
```

In this case I really only want to trigger rebuilds when changing one of the listed file types.

Chokidar supports all this out of the box btw.

Let me know what you think and thanks for the great project!
Cheers!