### PR TITLE
only exit on watch if stdin is TTY

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ if (argv.env) process.env.NODE_ENV = argv.env
 if (argv.config) argv.config = path.resolve(argv.config)
 
 if (argv.watch) {
-  process.stdin.on('end', () => process.exit(0))
+  process.on('SIGINT', () => process.exit(0))
   process.stdin.resume()
 }
 


### PR DESCRIPTION
check if stdin is TTY before checking "end" event,
as non-TTY stdin will always invoke end and exit.

found from running "postcss -w" in a docker container (#370)
and running "postcss -w" in lerna or turborepo.

closes #426 