### PR TITLE
Revamp README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,26 +1,35 @@
-[![npm][npm]][npm-url]
-[![node][node]][node-url]
-[![tests][tests]][tests-url]
-[![cover][cover]][cover-url]
-[![chat][chat]][chat-url]
+https://github.com/postcss/postcss[image:http://postcss.github.io/postcss/logo.svg[CLI,100,100,hspace=10,align=middle]]
 
-<div align="center">
-  <img width="100" height="100" title="CLI" src="https://raw.githubusercontent.com/postcss/postcss-cli/HEAD/logo.svg">
-  <a href="https://github.com/postcss/postcss">
-    <img width="110" height="110" title="PostCSS" src="http://postcss.github.io/postcss/logo.svg" hspace="10">
-  </a>
-  <h1>PostCSS CLI</h1>
-</div>
+= PostCSS CLI
+:npm: image:https://img.shields.io/npm/v/postcss-cli.svg
+:npm-url: https://npmjs.com/package/postcss-cli
+:node: image:https://img.shields.io/node/v/postcss-cli.svg
+:node-url: https://nodejs.org/
+:tests: image:https://img.shields.io/github/workflow/status/postcss/postcss-cli/Node.js%20CI/master
+:tests-url: https://github.com/postcss/postcss-cli/actions?query=branch%3Amaster
+:cover: image:https://img.shields.io/coveralls/postcss/postcss-cli/master.svg
+:cover-url: https://coveralls.io/github/postcss/postcss-cli
+:chat: image:https://img.shields.io/gitter/room/postcss/postcss.svg
+:chat-url: https://gitter.im/postcss/postcss
 
-<h2 align="center">Install</h2>
+{npm-url}[{npm}[]]
+{node-url}[{node}[]]
+{tests-url}[{tests}[]]
+{cover-url}[{cover}[]]
+{chat-url}[{chat}[]]
 
-```bash
-npm i -D postcss postcss-cli
-```
+== Install
 
-<h2 align="center">Usage</h2>
+[source,console]
+----
+$ npm i -D postcss postcss-cli
+----
 
-```
+== Usage
+
+[source,console]
+----
+$ postcss --help
 Usage:
   postcss [input.css] [OPTIONS] [-o|--output output.css] [--watch|-w]
   postcss <input.css>... [OPTIONS] --dir <output-directory> [--watch|-w]
@@ -73,17 +82,17 @@ If there are multiple input files, the --dir or --replace option must be passed.
 Input files may contain globs (e.g. src/**/*.css). If you pass an input
 directory, it will process all files in the directory and any subdirectories,
 respecting the glob pattern.
-```
+----
 
-> ℹ️ More details on custom parsers, stringifiers and syntaxes, can be found [here](https://github.com/postcss/postcss#syntaxes).
+NOTE: More details on custom parsers, stringifiers and syntaxes, can be found https://github.com/postcss/postcss#syntaxes[here].
 
-### [Config](https://github.com/michael-ciniawsky/postcss-load-config)
+=== https://github.com/michael-ciniawsky/postcss-load-config[Config]
 
-If you need to pass options to your plugins, or have a long plugin chain, you'll want to use a configuration file.
+If you need to pass options to your plugins, or have a long plugin chain, you’ll want to use a configuration file.
 
-**postcss.config.js**
-
-```js
+.`postcss.config.js`
+[source,javascript]
+----
 module.exports = {
   parser: 'sugarss',
   plugins: [
@@ -91,23 +100,27 @@ module.exports = {
     require('postcss-url')({ url: 'copy', useHash: true }),
   ],
 }
-```
+----
 
-Note that you **can not** set the `from` or `to` options for postcss in the config file. They are set automatically based on the CLI arguments.
+Note that you **cannot** set the `from` or `to` options for postcss in the config file; they are set automatically based on the CLI arguments.
 
-### Context
+=== Context
 
-For more advanced usage, it's recommended to use a function in `postcss.config.js`; this gives you access to the CLI context to dynamically apply options and plugins **per file**
+For more advanced usage, it’s recommended to use a function in `postcss.config.js`; this gives you access to the CLI context to dynamically apply options and plugins **per file**
 
-|   Name    |    Type    |              Default               | Description          |
-| :-------: | :--------: | :--------------------------------: | :------------------- |
-|   `env`   | `{String}` |          `'development'`           | process.env.NODE_ENV |
-|  `file`   | `{Object}` |    `dirname, basename, extname`    | File                 |
-| `options` | `{Object}` | `map, parser, syntax, stringifier` | PostCSS Options      |
+[cols=4*,options=header]
+|===
+| Name      | Type       | Default                            | Description
 
-**postcss.config.js**
+| `env`     | `{String}` | `'development'`                    | `process.env.NODE_ENV`
+| `file`    | `{Object}` | `dirname, basename, extname`       | File
+| `options` | `{Object}` | `map, parser, syntax, stringifier` | PostCSS Options
+|===
 
-```js
+
+.`postcss.config.js`
+[source,javascript]
+----
 module.exports = (ctx) => ({
   map: ctx.options.map,
   parser: ctx.file.extname === '.sss' ? 'sugarss' : false,
@@ -116,17 +129,18 @@ module.exports = (ctx) => ({
     cssnano: ctx.env === 'production' ? {} : false,
   },
 })
-```
+----
 
-> ⚠️ If you want to set options via CLI, it's mandatory to reference `ctx.options` in `postcss.config.js`
+CAUTION: If you want to set options via CLI, it’s mandatory to reference `ctx.options` in `postcss.config.js`
 
-```bash
-postcss input.sss -p sugarss -o output.css -m
-```
+[source,console]
+----
+$ postcss input.sss -p sugarss -o output.css -m
+----
 
-**postcss.config.js**
-
-```js
+.`postcss.config.js`
+[source,javascript]
+----
 module.exports = (ctx) => ({
   map: ctx.options.map,
   parser: ctx.options.parser,
@@ -135,15 +149,4 @@ module.exports = (ctx) => ({
     cssnano: ctx.env === 'production' ? {} : false,
   },
 })
-```
-
-[npm]: https://img.shields.io/npm/v/postcss-cli.svg
-[npm-url]: https://npmjs.com/package/postcss-cli
-[node]: https://img.shields.io/node/v/postcss-cli.svg
-[node-url]: https://nodejs.org/
-[tests]: https://img.shields.io/github/workflow/status/postcss/postcss-cli/Node.js%20CI/master
-[tests-url]: https://github.com/postcss/postcss-cli/actions?query=branch%3Amaster
-[cover]: https://img.shields.io/coveralls/postcss/postcss-cli/master.svg
-[cover-url]: https://coveralls.io/github/postcss/postcss-cli
-[chat]: https://img.shields.io/gitter/room/postcss/postcss.svg
-[chat-url]: https://gitter.im/postcss/postcss
+----


### PR DESCRIPTION
* Markdown → AsciiDoc
* Incorrect usage of blockquotes → Admonitions
* Incorrect Bash syntax blocks → Console syntax
* Block headings instead of floating paragraphs with bold text
* Typographic apostrophes
* Remove unnecessary HTML that makes it harder to read as plaintext

---

To see this rendered: https://github.com/toastal/postcss-cli/blob/readme/README.adoc
To see it raw: https://raw.githubusercontent.com/toastal/postcss-cli/readme/README.adoc

READMEs however should require minimal rendering (or it would be called RENDERME). As such I believe AsciiDoc offers a richer feature set. Currently the README is optimized for... GitHub's rendering? And as such includes a number misused elements and markup that doesn't need to exist. I believe GitHub support of AsciiDoc will continue to improve, especially with admonitions. Maybe the macros for the URLs aren't really needed though as it adds a big block of not really much value. Some comments would do better IMO, but I wanted to keep the general README structure.