### PR TITLE
Allow non-TTY stdin watch mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,13 @@ let configFile
 if (argv.env) process.env.NODE_ENV = argv.env
 if (argv.config) argv.config = path.resolve(argv.config)
 
-if (argv.watch) {
+let { isTTY } = process.stdin
+
+if (process.env.FORCE_IS_TTY === 'true') {
+  isTTY = true
+}
+
+if (argv.watch && isTTY) {
   process.stdin.on('end', () => process.exit(0))
   process.stdin.resume()
 }

--- a/test/watch.js
+++ b/test/watch.js
@@ -205,6 +205,10 @@ testCb('--watch does exit on closing stdin (Ctrl-D/EOF)', (t) => {
 
   const cp = spawn(`./index.js test/fixtures/a.css -o ${tmp()} -w --no-map`, {
     shell: true,
+    env: {
+      ...process.env,
+      FORCE_IS_TTY: true,
+    },
   })
 
   cp.on('error', t.end)
@@ -212,6 +216,7 @@ testCb('--watch does exit on closing stdin (Ctrl-D/EOF)', (t) => {
     t.is(code, 0)
     t.end()
   })
+
   cp.stdin.end()
 })
 


### PR DESCRIPTION
The presence of stdin doesn't necessarily mean there's an allocated tty. This breaks watch mode in non-TTY stdin contexts (e.g. docker, foreman, etc). A simple process.stdin.isTTY check would theoretically be enough but unfortunately, subprocesses don't have the same API, and they are used extensively for testing via calls to the function `spawn`.

A simple solution is to inject an env var dependency where we tell the process that it's indeed a TTY-allocated process and so, watch mode with exit handling is good to go.

A more robust but also annoying solution would involve using an actual terminal emulator (like [Microsoft's node-pty](https://github.com/microsoft/node-pty)). Though the environment gets exponentially more difficult to setup since it
involves compiling bindings, which require different requirements per OS.

Closes https://github.com/postcss/postcss-cli/pull/424