### PR TITLE
Update postcss-load-config version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "get-stdin": "^9.0.0",
     "globby": "^13.0.0",
     "picocolors": "^1.0.0",
-    "postcss-load-config": "^4.0.0",
+    "postcss-load-config": "^4.0.1",
     "postcss-reporter": "^7.0.0",
     "pretty-hrtime": "^1.0.3",
     "read-cache": "^1.0.0",


### PR DESCRIPTION
Earlier version depends on a yaml version that has a moderate security bug. See the following for more details: https://github.com/advisories/GHSA-f9xv-q969-pqx4