### PR TITLE
feat: replace globby with tinyglobby and remove get-stdin in favor of stream.consumers.text

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,10 +4,10 @@ import fs from 'fs-extra'
 import path from 'path'
 
 import prettyHrtime from 'pretty-hrtime'
-import stdin from 'get-stdin'
+import { text } from 'stream/consumers'
 import read from 'read-cache'
 import pc from 'picocolors'
-import { globby } from 'globby'
+import { glob } from 'tinyglobby'
 import slash from 'slash'
 import chokidar from 'chokidar'
 
@@ -86,7 +86,7 @@ buildCliConfig()
     }
 
     if (input && input.length) {
-      return globby(
+      return glob(
         input.map((i) => slash(String(i))),
         { dot: argv.includeDotfiles },
       )
@@ -188,7 +188,7 @@ function files(files) {
   return Promise.all(
     files.map((file) => {
       if (file === 'stdin') {
-        return stdin().then((content) => {
+        return text(process.stdin).then((content) => {
           if (!content) return error('Input Error: Did not receive any STDIN')
           return css(content, 'stdin')
         })

--- a/package.json
+++ b/package.json
@@ -21,14 +21,13 @@
     "chokidar": "^3.3.0",
     "dependency-graph": "^1.0.0",
     "fs-extra": "^11.0.0",
-    "get-stdin": "^9.0.0",
-    "globby": "^14.0.0",
     "picocolors": "^1.0.0",
     "postcss-load-config": "^5.0.0",
     "postcss-reporter": "^7.0.0",
     "pretty-hrtime": "^1.0.3",
     "read-cache": "^1.0.0",
     "slash": "^5.0.0",
+    "tinyglobby": "^0.2.12",
     "yargs": "^17.0.0"
   },
   "devDependencies": {

--- a/test/helpers/env.js
+++ b/test/helpers/env.js
@@ -1,6 +1,6 @@
 import fs from 'fs-extra'
 import path from 'path'
-import { globby } from 'globby'
+import { glob } from 'tinyglobby'
 
 import tmp from './tmp.js'
 
@@ -8,7 +8,7 @@ export default function (config, fixtures = '**/*', extension = 'cjs') {
   const dir = tmp()
 
   return Promise.all([
-    globby(fixtures, { cwd: 'test/fixtures' }).then((list) => {
+    glob(fixtures, { cwd: 'test/fixtures' }).then((list) => {
       return list.map((item) => {
         return fs.copy(path.join('test/fixtures', item), path.join(dir, item))
       })


### PR DESCRIPTION
all tests pass

backwards compaible change (stream/consumers are supported since node 16.x)

see https://github.com/sindresorhus/get-stdin/tree/main?tab=readme-ov-file#tip