### PR TITLE
chore: replace fs-extra with native Node.js fs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import fs from 'fs-extra'
+import fs from 'node:fs/promises'
 import path from 'path'
 
 import prettyHrtime from 'pretty-hrtime'
@@ -286,10 +286,14 @@ function css(css, file) {
     })
 
   async function outputFile(file, string) {
-    const fileExists = await fs.pathExists(file)
+    const fileExists = await fs.access(file).then(
+      () => true,
+      () => false,
+    )
     const currentValue = fileExists ? await fs.readFile(file, 'utf8') : null
     if (currentValue === string) return
-    return fs.outputFile(file, string)
+    await fs.mkdir(path.dirname(file), { recursive: true })
+    return fs.writeFile(file, string)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "chokidar": "^3.3.0",
     "dependency-graph": "^1.0.0",
-    "fs-extra": "^11.0.0",
     "picocolors": "^1.0.0",
     "postcss-load-config": "^5.0.0",
     "postcss-reporter": "^7.0.0",

--- a/test/ext.js
+++ b/test/ext.js
@@ -1,6 +1,6 @@
 import test from 'ava'
 
-import fs from 'fs-extra'
+import fs from 'node:fs/promises'
 import path from 'path'
 
 import cli from './helpers/cli.js'
@@ -20,7 +20,12 @@ test('--ext works', async (t) => {
   ])
   t.falsy(error, stderr)
 
-  t.truthy(await fs.pathExists(path.join(dir, 'a.css')))
+  t.truthy(
+    await fs.access(path.join(dir, 'a.css')).then(
+      () => true,
+      () => false,
+    ),
+  )
 })
 
 test('--ext works with no leading dot', async (t) => {
@@ -37,5 +42,10 @@ test('--ext works with no leading dot', async (t) => {
   ])
   t.falsy(error, stderr)
 
-  t.truthy(await fs.pathExists(path.join(dir, 'a.css')))
+  t.truthy(
+    await fs.access(path.join(dir, 'a.css')).then(
+      () => true,
+      () => false,
+    ),
+  )
 })

--- a/test/helpers/clean.js
+++ b/test/helpers/clean.js
@@ -1,8 +1,10 @@
-import fs from 'fs-extra'
+import fs from 'node:fs/promises'
 
 Promise.all([
-  fs.emptyDir('./test/fixtures/.tmp/'),
-  fs.remove('./coverage'),
+  fs
+    .rm('./test/fixtures/.tmp/', { recursive: true, force: true })
+    .then(() => fs.mkdir('./test/fixtures/.tmp/', { recursive: true })),
+  fs.rm('./coverage', { recursive: true, force: true }),
 ]).catch((err) => {
   console.error(err)
   process.exit(1)

--- a/test/helpers/env.js
+++ b/test/helpers/env.js
@@ -4,21 +4,21 @@ import { glob } from 'tinyglobby'
 
 import tmp from './tmp.js'
 
-export default function (config, fixtures = '**/*', extension = 'cjs') {
+export default async function (config, fixtures = '**/*', extension = 'cjs') {
   const dir = tmp()
 
-  return fs.mkdir(dir, { recursive: true }).then(() =>
-    Promise.all([
-      glob(fixtures, { cwd: 'test/fixtures' }).then((list) => {
-        return Promise.all(
-          list.map(async (item) => {
-            const dest = path.join(dir, item)
-            await fs.mkdir(path.dirname(dest), { recursive: true })
-            return fs.copyFile(path.join('test/fixtures', item), dest)
-          }),
-        )
-      }),
-      fs.writeFile(path.join(dir, `postcss.config.${extension}`), config),
-    ]).then(() => dir),
-  )
+  await fs.mkdir(dir, { recursive: true })
+
+  const list = await glob(fixtures, { cwd: 'test/fixtures' })
+
+  await Promise.all([
+    ...list.map(async (item) => {
+      const dest = path.join(dir, item)
+      await fs.mkdir(path.dirname(dest), { recursive: true })
+      await fs.copyFile(path.join('test/fixtures', item), dest)
+    }),
+    fs.writeFile(path.join(dir, `postcss.config.${extension}`), config),
+  ])
+
+  return dir
 }

--- a/test/helpers/env.js
+++ b/test/helpers/env.js
@@ -1,4 +1,4 @@
-import fs from 'fs-extra'
+import fs from 'node:fs/promises'
 import path from 'path'
 import { glob } from 'tinyglobby'
 
@@ -7,12 +7,18 @@ import tmp from './tmp.js'
 export default function (config, fixtures = '**/*', extension = 'cjs') {
   const dir = tmp()
 
-  return Promise.all([
-    glob(fixtures, { cwd: 'test/fixtures' }).then((list) => {
-      return list.map((item) => {
-        return fs.copy(path.join('test/fixtures', item), path.join(dir, item))
-      })
-    }),
-    fs.outputFile(path.join(dir, `postcss.config.${extension}`), config),
-  ]).then(() => dir)
+  return fs.mkdir(dir, { recursive: true }).then(() =>
+    Promise.all([
+      glob(fixtures, { cwd: 'test/fixtures' }).then((list) => {
+        return Promise.all(
+          list.map(async (item) => {
+            const dest = path.join(dir, item)
+            await fs.mkdir(path.dirname(dest), { recursive: true })
+            return fs.copyFile(path.join('test/fixtures', item), dest)
+          }),
+        )
+      }),
+      fs.writeFile(path.join(dir, `postcss.config.${extension}`), config),
+    ]).then(() => dir),
+  )
 }

--- a/test/helpers/read.js
+++ b/test/helpers/read.js
@@ -1,4 +1,4 @@
-import fs from 'fs-extra'
+import fs from 'node:fs/promises'
 
 export default function (path) {
   return fs.readFile(path, 'utf8').then(

--- a/test/map.js
+++ b/test/map.js
@@ -1,5 +1,5 @@
 import test from 'ava'
-import fs from 'fs-extra'
+import fs from 'node:fs/promises'
 
 import cli from './helpers/cli.js'
 import tmp from './helpers/tmp.js'
@@ -35,7 +35,12 @@ test('--map generates external sourcemaps', async (t) => {
 
   t.falsy(error, stderr)
 
-  t.truthy(await fs.pathExists(output.replace('.css', '.css.map')))
+  t.truthy(
+    await fs.access(output.replace('.css', '.css.map')).then(
+      () => true,
+      () => false,
+    ),
+  )
 })
 
 test('--no-map disables internal sourcemaps', async (t) => {

--- a/test/replace.js
+++ b/test/replace.js
@@ -1,6 +1,6 @@
 import test from 'ava'
 
-import fs from 'fs-extra'
+import fs from 'node:fs/promises'
 import path from 'path'
 
 import cli from './helpers/cli.js'
@@ -12,9 +12,10 @@ test('--replace works', async (t) => {
 
   const output = path.join(dir, 'output.css')
 
+  await fs.mkdir(dir, { recursive: true })
   await Promise.all([
-    fs.copy('test/fixtures/import.css', output),
-    fs.copy('test/fixtures/a.css', path.join(dir, 'a.css')),
+    fs.copyFile('test/fixtures/import.css', output),
+    fs.copyFile('test/fixtures/a.css', path.join(dir, 'a.css')),
   ])
 
   const { error, stderr } = await cli([

--- a/test/stdin.js
+++ b/test/stdin.js
@@ -1,6 +1,6 @@
 import test from 'ava'
 
-import fs from 'fs-extra'
+import { createReadStream } from 'node:fs'
 import path from 'path'
 import { exec } from 'child_process'
 
@@ -24,5 +24,5 @@ test.cb('reads from stdin', (t) => {
     },
   )
 
-  fs.createReadStream('test/fixtures/a.css').pipe(cp.stdin)
+  createReadStream('test/fixtures/a.css').pipe(cp.stdin)
 })

--- a/test/stdout.js
+++ b/test/stdout.js
@@ -1,6 +1,6 @@
 import test from 'ava'
 
-import fs from 'fs-extra'
+import { createReadStream } from 'node:fs'
 import path from 'path'
 import { exec } from 'child_process'
 
@@ -23,5 +23,5 @@ test.cb('writes to stdout', (t) => {
     },
   )
 
-  fs.createReadStream('./test/fixtures/a.sss').pipe(cp.stdin)
+  createReadStream('./test/fixtures/a.sss').pipe(cp.stdin)
 })

--- a/test/unchanged.js
+++ b/test/unchanged.js
@@ -1,4 +1,4 @@
-import fs from 'fs-extra'
+import fs from 'node:fs/promises'
 import test from 'ava'
 
 import cli from './helpers/cli.js'

--- a/test/watch.js
+++ b/test/watch.js
@@ -1,6 +1,6 @@
 import test from 'ava'
 
-import fs from 'fs-extra'
+import fs from 'node:fs/promises'
 import path from 'path'
 import { exec, spawn } from 'child_process'
 import chokidar from 'chokidar'


### PR DESCRIPTION
## Summary

- Replace `fs-extra` with native `node:fs/promises` and `node:fs` APIs
- All replacements available on supported Node >= 18
- Removes 1 runtime dependency (fs-extra + 3 transitive deps)

Follows the same pattern as #489 (globby → tinyglobby).

## Changes

**Source (1 file):**
- `index.js` — `fs.pathExists()` → `fs.access()`, `fs.outputFile()` → `fs.mkdir()` + `fs.writeFile()`

**Tests (10 files):**
- `test/helpers/clean.js` — `fs.emptyDir()` → `fs.rm()` + `fs.mkdir()`, `fs.remove()` → `fs.rm()`
- `test/helpers/env.js` — `fs.copy()` → `fs.copyFile()`, `fs.outputFile()` → `fs.writeFile()`
- `test/helpers/read.js` — import swap only
- `test/stdin.js`, `test/stdout.js` — `fs.createReadStream()` → named import from `node:fs`
- `test/ext.js`, `test/map.js` — `fs.pathExists()` → `fs.access()`
- `test/replace.js` — `fs.copy()` → `fs.copyFile()`
- `test/unchanged.js`, `test/watch.js` — import swap only

**package.json** — removed `fs-extra` from dependencies

## Replacement mapping

| fs-extra | Native (Node >= 18) |
|----------|-------------------|
| `pathExists()` | `access().then(() => true, () => false)` |
| `outputFile()` | `mkdir({ recursive: true })` + `writeFile()` |
| `copy()` | `copyFile()` (glob ensures file-only results) |
| `emptyDir()` | `rm({ recursive, force })` + `mkdir({ recursive })` |
| `remove()` | `rm({ recursive, force })` |
| `createReadStream()` | Named import from `node:fs` |

## Testing

All 39 tests pass. ESLint and Prettier clean.